### PR TITLE
add redirect from /getting-started to /get-on-the-network

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,11 @@
       "source": "/install/macos-x86_64/latest",
       "destination": "https://github.com/urbit/vere/releases/latest/download/macos-x86_64.tgz",
       "permanent": true
+    },
+    {
+      "source": "/getting-started",
+      "destination": "/get-on-the-network",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
urbit.org/getting-started is referenced in the urbit/urbit repo readme and elsewhere but currently 404s