### PR TITLE
Add Umami anayltics

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -7,19 +7,19 @@ import { FooterSection } from "./components/FooterSection";
 export async function generateMetadata({ params }, parent) {
   const config = await getMarkdownContent("config.md");
   const metadata = config.frontMatter.site_metadata;
-  
+
   return {
     title: `${config.frontMatter.title} — ${config.frontMatter.subtitle}`,
     description: `${config.frontMatter?.description}`,
     openGraph: {
-        images: [
-            {
-                url: `${metadata.meta_image}`,
-                alt: `${metadata.meta_image_alt}`,
-                width: 1200,
-                height: 630,
-            },
-        ]
+      images: [
+        {
+          url: `${metadata.meta_image}`,
+          alt: `${metadata.meta_image_alt}`,
+          width: 1200,
+          height: 630,
+        },
+      ]
     },
   };
 }
@@ -29,6 +29,9 @@ export default async function RootLayout({ children }) {
 
   return (
     <html lang="en">
+      <head>
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="bf47fa30-3b27-43fc-af86-e6bfcb739881"></script>
+      </head>
       <body className="min-h-[100svh] flex flex-col w-full relative" id="observer-root">
         <div className="w-[100%] flex justify-center container">
           <HeaderNav homepage={config.frontMatter?.homepage} nav={config.frontMatter?.nav} />


### PR DESCRIPTION
Opening this PR to add basic Umami analytics to the site. Umami is an open-source, privacy-friendly analytics platform that is GDPR and CCPA complaint and doesn't leave cookies or other personalized trackers on a user. It gives us basic info about page views, referrals, etc. and will help us better understand what kind of web content is most compelling to our site visitors.